### PR TITLE
FTP encoding 지원을 위한 생성자 추가

### DIFF
--- a/src/main/java/me/saro/commons/ftp/FTP.java
+++ b/src/main/java/me/saro/commons/ftp/FTP.java
@@ -54,6 +54,26 @@ public interface FTP extends Closeable {
     public static FTP openFTP(String host, int port, String user, String pass) throws IOException {
         return new FTPS(InetAddress.getByName(host), port, user, pass, false);
     }
+
+    /**
+     * open ftp
+     * @param host
+     * ip or domain
+     * @param port
+     * port (ftp basic port 21)
+     * @param user
+     * username
+     * @param pass
+     * password
+     * @param encoding
+     * encoding
+     * @return
+     * FTP Object
+     * @throws IOException
+     */
+    public static FTP openFTP(String host, int port, String user, String pass, String encoding) throws IOException {
+        return new FTPS(InetAddress.getByName(host), port, user, pass, false, encoding);
+    }
     
     /**
      * open ftps

--- a/src/main/java/me/saro/commons/ftp/FTPS.java
+++ b/src/main/java/me/saro/commons/ftp/FTPS.java
@@ -49,6 +49,11 @@ public class FTPS implements FTP {
            throw e;
         }
     }
+
+    public FTPS(InetAddress byName, int port, String user, String pass, boolean isFTPS, String encoding) throws IOException {
+        this(byName, port, user, pass, isFTPS);
+        ftp.setControlEncoding(encoding);
+    }
     
     /**
      * BINARY FILE MODE<br>


### PR DESCRIPTION
saro-lab님 안녕하세요?

만들어 주신 랩퍼 잘 쓰고 있습니다. 
다만 ftp 생성 시 인코딩을 지정할 수 없어서, 내부에 인코딩 매개변수를 추가할 수 있는 생성자를 추가했습니다.
기존 apache common에 있는 ftp에서 지원하는 기능입니다.

인코딩
```
// 이런식으로 사용가능하고, 예를 들어 ftp에 있는 한글 폴더 리스트를 출력하면 한글이 잘나오게 됩니다.
String encoding = "euc-kr"
FTP ftp = FTP.openFTP(host, port, user, pass, encoding);
```
감사합니다.